### PR TITLE
40 api docs require sub account header where applicable

### DIFF
--- a/openapi/multi-yaml/components/parameters/sub-account-required.yaml
+++ b/openapi/multi-yaml/components/parameters/sub-account-required.yaml
@@ -1,0 +1,8 @@
+in: header
+name: Sub-Account
+schema:
+  type: string
+required: true
+example: "acc_123xyz"
+description: |
+  for platforms, the id of the [sub account](https://docs.justifi.tech/api-spec#tag/Sub-Accounts) that this request applies to

--- a/openapi/multi-yaml/components/parameters/sub-account-required.yaml
+++ b/openapi/multi-yaml/components/parameters/sub-account-required.yaml
@@ -5,4 +5,4 @@ schema:
 required: true
 example: "acc_123xyz"
 description: |
-  for platforms, the id of the [sub account](https://docs.justifi.tech/api-spec#tag/Sub-Accounts) that this request applies to
+  the id of the [sub account](https://docs.justifi.tech/api-spec#tag/Sub-Accounts) that this request applies to

--- a/openapi/multi-yaml/components/parameters/sub-account.yaml
+++ b/openapi/multi-yaml/components/parameters/sub-account.yaml
@@ -5,4 +5,4 @@ schema:
 required: false
 example: "acc_123xyz"
 description: |
-  for platforms, the id of the [sub account](https://docs.justifi.tech/api-spec#tag/Sub-Accounts) that this request applies to
+  the id of the [sub account](https://docs.justifi.tech/api-spec#tag/Sub-Accounts) that this request applies to

--- a/openapi/multi-yaml/paths/payment_intents.yaml
+++ b/openapi/multi-yaml/paths/payment_intents.yaml
@@ -3,7 +3,7 @@ post:
   description: |
     Create a payment intent if you'd like a place to track the payment method along with all payment attempts for a payment.
 
-    *Note: For platforms, if the sub account status is not `enabled`, `400` will be returned.*
+    *Note: If the sub account status is not `enabled`, `400` will be returned.*
   operationId: CreatePaymentIntent
   tags:
     - Payment Intents

--- a/openapi/multi-yaml/paths/payment_intents.yaml
+++ b/openapi/multi-yaml/paths/payment_intents.yaml
@@ -10,7 +10,7 @@ post:
   parameters:
     - $ref: ../components/parameters/idempotency-key-header.yaml
     - $ref: ../components/parameters/authorization-header.yaml
-    - $ref: ../components/parameters/sub-account.yaml
+    - $ref: ../components/parameters/sub-account-required.yaml
   requestBody:
     required: true
     content:

--- a/openapi/multi-yaml/paths/payment_intents@{id}@capture.yaml
+++ b/openapi/multi-yaml/paths/payment_intents@{id}@capture.yaml
@@ -3,7 +3,7 @@ post:
   description: |
     Capturing a payment intent lets JustiFi know you intend to process a payment. JustiFi will charge the attached payment method and create a payment.
 
-    *Note: For platforms, if the sub account status is not `enabled`, `400` will be returned.*
+    *Note: If the sub account status is not `enabled`, `400` will be returned.*
   operationId: CapturePaymentIntent
   parameters:
     - $ref: ../components/parameters/id-path.yaml

--- a/openapi/multi-yaml/paths/payment_method_groups.yaml
+++ b/openapi/multi-yaml/paths/payment_method_groups.yaml
@@ -7,7 +7,7 @@ post:
     - Payment Method Groups
   parameters:
     - $ref: ../components/parameters/authorization-header.yaml
-    - $ref: ../components/parameters/sub-account.yaml
+    - $ref: ../components/parameters/sub-account-required.yaml
   responses:
     '201':
       description: Payment method group was created successfully

--- a/openapi/multi-yaml/paths/payment_methods.yaml
+++ b/openapi/multi-yaml/paths/payment_methods.yaml
@@ -11,7 +11,7 @@ post:
   parameters:
     - $ref: ../components/parameters/idempotency-key-header.yaml
     - $ref: ../components/parameters/authorization-header.yaml
-    - $ref: ../components/parameters/sub-account.yaml
+    - $ref: ../components/parameters/sub-account-required.yaml
   requestBody:
     required: true
     content:

--- a/openapi/multi-yaml/paths/payment_methods.yaml
+++ b/openapi/multi-yaml/paths/payment_methods.yaml
@@ -4,7 +4,7 @@ post:
     You can create payment methods ahead of time, then pass their existing tokens to payments.
     Alternatively, you can create and tokenize payment methods inline when processing payments.
 
-    *Note: For platforms, if the sub account status is not `enabled`, `400` will be returned.*
+    *Note: If the sub account status is not `enabled`, `400` will be returned.*
   operationId: CreatePaymentMethod
   tags:
     - Payment Methods

--- a/openapi/multi-yaml/paths/payments.yaml
+++ b/openapi/multi-yaml/paths/payments.yaml
@@ -10,7 +10,7 @@ post:
   parameters:
     - $ref: ../components/parameters/idempotency-key-header.yaml
     - $ref: ../components/parameters/authorization-header.yaml
-    - $ref: ../components/parameters/sub-account.yaml
+    - $ref: ../components/parameters/sub-account-required.yaml
   requestBody:
     required: true
     content:

--- a/openapi/multi-yaml/paths/payments@{id}@capture.yaml
+++ b/openapi/multi-yaml/paths/payments@{id}@capture.yaml
@@ -3,7 +3,7 @@ post:
   description: |
     To charge a payment method and capture a previously authorized payment.  Returns a `payment_already_captured` error if the payment is in a captured state.
 
-    *Note: For platforms, if the sub account status is not `enabled`, `400` will be returned.*
+    *Note: If the sub account status is not `enabled`, `400` will be returned.*
   operationId: CapturePayment
   parameters:
     - $ref: ../components/parameters/id-path.yaml

--- a/openapi/multi-yaml/paths/payments@{id}@refunds.yaml
+++ b/openapi/multi-yaml/paths/payments@{id}@refunds.yaml
@@ -6,7 +6,7 @@ post:
   description: |
     Issue a refund for a payment. You may refund the full payment amount or just a portion. When refunding a portion, multiple refunds are supported up until the full payment amount has been refunded.
 
-    *Note: For platforms, if the sub account status is not `enabled`, `400` will be returned.*
+    *Note: If the sub account status is not `enabled`, `400` will be returned.*
   operationId: CreateRefund
   parameters:
     - in: path


### PR DESCRIPTION
- feat: yaml for required sub-account header
- feat: use required sub-account header where needed
