### PR TITLE
Adjust config to use the latest version as default

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -3,6 +3,9 @@ import { themes as prismThemes } from "prism-react-renderer";
 import type { Config } from "@docusaurus/types";
 import type * as Preset from "@docusaurus/preset-classic";
 
+const wcPackageJson = require('./.wc-current/package.json');
+const wcVersion = wcPackageJson.dependencies?.['@justifi/webcomponents'] || 'Latest';
+
 const config: Config = {
   title: "JustiFi Documentation",
   tagline: "JustiFi - Fintech Infrastructure for Platforms",
@@ -90,7 +93,8 @@ const config: Config = {
         routeBasePath: 'web-components',
         sidebarPath: require.resolve('./sidebars.web-components.js'),
         includeCurrentVersion: true,
-        versions: { current: { label: '6.13', banner: 'none' } },
+        lastVersion: 'current',
+        versions: { current: { label: '6.13', path: '6.13', banner: 'none' } },
         // Exclude templates and internal helper files from being parsed as docs
         exclude: [
           '**/templates/**',

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -3,9 +3,6 @@ import { themes as prismThemes } from "prism-react-renderer";
 import type { Config } from "@docusaurus/types";
 import type * as Preset from "@docusaurus/preset-classic";
 
-const wcPackageJson = require('./.wc-current/package.json');
-const wcVersion = wcPackageJson.dependencies?.['@justifi/webcomponents'] || 'Latest';
-
 const config: Config = {
   title: "JustiFi Documentation",
   tagline: "JustiFi - Fintech Infrastructure for Platforms",

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -91,7 +91,7 @@ const config: Config = {
         sidebarPath: require.resolve('./sidebars.web-components.js'),
         includeCurrentVersion: true,
         lastVersion: 'current',
-        versions: { current: { label: '6.13', path: '6.13', banner: 'none' } },
+        versions: { current: { label: '6.13', banner: 'none' } },
         // Exclude templates and internal helper files from being parsed as docs
         exclude: [
           '**/templates/**',


### PR DESCRIPTION
By default, Docusaurus treats the latest version as `next`. These changes adjust the last version to be current, and current to show the version in the URL as well.

<img width="895" height="198" alt="Screenshot 2026-04-15 at 10 02 56" src="https://github.com/user-attachments/assets/211cecc2-49ab-4064-89cb-9c7ca0d8a667" />


https://docusaurus.io/docs/versioning#configuring-versioning-behavior