### PR TITLE
Add date filter to payment methods index

### DIFF
--- a/openapi/multi-yaml/paths/payment_methods.yaml
+++ b/openapi/multi-yaml/paths/payment_methods.yaml
@@ -158,6 +158,8 @@ get:
     - $ref: ../components/parameters/sub-account.yaml
     - $ref: ../components/parameters/customer-id.yaml
     - $ref: ../components/parameters/payment-method-group-id.yaml
+    - $ref: ../components/parameters/created-before.yaml
+    - $ref: ../components/parameters/created-after.yaml
   responses:
     '200':
       description: Successfully list payment methods


### PR DESCRIPTION
After [index was added to payment method `created_at` column](https://github.com/justifi-tech/vault/pull/1734) we can safely document the date filter that was added to the payment methods index.
Unblocks https://github.com/justifi-tech/engineering-artifacts/issues/2278 (was already implemented)