### PR TITLE
Document ownership_percentage on identity/owners payload

### DIFF
--- a/openapi/multi-yaml/components/schemas/Identity.yaml
+++ b/openapi/multi-yaml/components/schemas/Identity.yaml
@@ -40,7 +40,7 @@ properties:
     minimum: 0
     maximum: 100
     example: 25
-    description: percentage of the business owned by this identity (0–100); applies when is_owner is true
+    description: percentage of the business owned by this identity (0–100); only returned when the identity owns a business (proprietor_id set), not based on the is_owner column. Only owners with at least 25% ownership should be included.
   metadata:
     type: object
     format: json

--- a/openapi/multi-yaml/components/schemas/Identity.yaml
+++ b/openapi/multi-yaml/components/schemas/Identity.yaml
@@ -35,6 +35,12 @@ properties:
   is_owner:
     type: boolean
     description: if an identity owns 25% or more of the business, they are considered an owner
+  ownership_percentage:
+    type: integer
+    minimum: 0
+    maximum: 100
+    example: 25
+    description: percentage of the business owned by this identity (0–100); applies when is_owner is true
   metadata:
     type: object
     format: json

--- a/openapi/multi-yaml/components/schemas/IdentityResponse.yaml
+++ b/openapi/multi-yaml/components/schemas/IdentityResponse.yaml
@@ -49,6 +49,12 @@ properties:
     type: boolean
     example: true
     description: if an identity owns 25% or more of the business, they are considered an owner
+  ownership_percentage:
+    type: integer
+    minimum: 0
+    maximum: 100
+    example: 25
+    description: percentage of the business owned by this identity (0–100); only returned when is_owner is true
   metadata:
     type: object
     format: json

--- a/openapi/multi-yaml/paths/entities_identity.yaml
+++ b/openapi/multi-yaml/paths/entities_identity.yaml
@@ -49,6 +49,12 @@ post:
               type: boolean
               example: true
               description: if an identity owns 25% or more of the business, they are considered an owner
+            ownership_percentage:
+              type: integer
+              minimum: 0
+              maximum: 100
+              example: 25
+              description: percentage of the business owned by this identity (0–100); applies when is_owner is true
             metadata:
               type: object
               description: any useful information you'd like to store alongside this identity

--- a/openapi/multi-yaml/paths/entities_identity@{id}.yaml
+++ b/openapi/multi-yaml/paths/entities_identity@{id}.yaml
@@ -48,6 +48,12 @@ patch:
             is_owner:
               type: boolean
               description: if an identity owns 25% or more of the business, they are considered an owner
+            ownership_percentage:
+              type: integer
+              minimum: 0
+              maximum: 100
+              example: 25
+              description: percentage of the business owned by this identity (0–100); applies when is_owner is true
             metadata:
               type: object
               description: any useful information you'd like to store alongside this identity


### PR DESCRIPTION
## Summary

The entity-management API already accepts and returns `ownership_percentage` for identities (the `owners[]` payload is typed as `IdentityParameters`), but it was undocumented in the OpenAPI spec. This adds it everywhere the Identity/owners payload is documented:

- `components/schemas/Identity.yaml` — request schema (business create/update `owners[]` + `representative`)
- `components/schemas/IdentityResponse.yaml` — response schema (business response `owners[]`, identity endpoints)
- `paths/entities_identity.yaml` — `POST /entities/identity` inline request body
- `paths/entities_identity@{id}.yaml` — `PATCH /entities/identity/{id}` inline request body

Field is `integer`, 0–100, matching the `numericality` validation in `IdentityParameters`. The response description notes it is only returned when `is_owner` is true, matching `IdentitySerializer` (`if: :is_owner?`).

## Out of scope

- Hosted-onboarding schemas (`OnboardingEntry*.yaml`) are intentionally left unchanged — that payload maps owners to `{name, email}` only.
- `business_id` / `platform_account_id` request fields left out per review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)