### PR TITLE
Add GitHub Pages deploy workflow

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -1,0 +1,72 @@
+name: Deploy to GitHub Pages
+
+# Deploys the Docusaurus site to GitHub Pages.
+#
+# Step 1 (current): served at https://justifi-tech.github.io/public-docs/
+#   SITE_BASE_URL must be '/public-docs/' so assets resolve under the
+#   project-page path.
+#
+# Step 2 (custom domain, later): to serve at https://docs.justifi.tech/,
+#   set SITE_URL to https://docs.justifi.tech and SITE_BASE_URL to '/',
+#   add the domain under Settings > Pages, and commit a static/CNAME file
+#   containing "docs.justifi.tech".
+
+on:
+  # Manual trigger so we control when the trial site publishes.
+  workflow_dispatch:
+  # Auto-publish on merges to main. Remove this block if you prefer
+  # manual-only deploys while Vercel remains the production site.
+  push:
+    branches:
+      - main
+
+# Allow the workflow to publish to Pages via OIDC.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# One deploy at a time; let an in-progress run finish (don't cancel).
+concurrency:
+  group: github-pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      SITE_URL: https://justifi-tech.github.io
+      SITE_BASE_URL: /public-docs/
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.6.2
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: build
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -8,11 +8,14 @@ const config: Config = {
   tagline: "JustiFi - Fintech Infrastructure for Platforms",
   favicon: "img/favicon.png",
 
-  // Set the production url of your site here
-  url: "https://docs.justifi.tech",
-  // Set the /<baseUrl>/ pathname under which your site is served
-  // For GitHub pages deployment, it is often '/<projectName>/'
-  baseUrl: "/",
+  // Set the production url of your site here.
+  // Defaults target the primary (Vercel) deploy at docs.justifi.tech.
+  // The GitHub Pages workflow overrides SITE_URL/SITE_BASE_URL so the site
+  // builds correctly under https://justifi-tech.github.io/public-docs/.
+  url: process.env.SITE_URL ?? "https://docs.justifi.tech",
+  // Set the /<baseUrl>/ pathname under which your site is served.
+  // For GitHub project pages this is '/<projectName>/' (e.g. '/public-docs/').
+  baseUrl: process.env.SITE_BASE_URL ?? "/",
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.


### PR DESCRIPTION
## What

Adds GitHub Pages deployment as a trial alongside the existing Vercel production deploy.

- **New workflow** `.github/workflows/deploy-gh-pages.yml` — builds the Docusaurus site and publishes to Pages at `https://justifi-tech.github.io/public-docs/`. Triggers on push to `main` and manual `workflow_dispatch`.
- **Env-driven `url`/`baseUrl`** in `docusaurus.config.ts` via `SITE_URL`/`SITE_BASE_URL`. Defaults are unchanged (`https://docs.justifi.tech`, `/`), so the **Vercel production build is unaffected**. The workflow overrides them to serve under the `/public-docs/` project-page path.

## Verification

Built locally with the Pages env vars (`SITE_URL=https://justifi-tech.github.io SITE_BASE_URL=/public-docs/ pnpm build`):
- `[SUCCESS] Generated static files` — the `onBrokenLinks: "throw"` gate passed.
- Confirmed generated HTML references assets under `/public-docs/`.
- One non-fatal broken-*anchor* warning exists (pre-existing, does not block the build).

## After merge — manual steps (repo admin)

1. Repo **Settings → Pages → Build and deployment → Source: GitHub Actions**.
2. Merge this PR (or run the workflow manually) to publish.

## Step 2 (later — `docs.justifi.tech` cutover)

To point the custom domain at Pages: set `SITE_URL=https://docs.justifi.tech` and `SITE_BASE_URL=/` in the workflow, add the domain under Settings → Pages, and commit `static/CNAME` containing `docs.justifi.tech`. (Coordinate with the existing Vercel deploy on that domain.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)