### PR TITLE
fix: pnpm version conflict in GitHub Pages workflow

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -40,13 +40,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Version is read from the "packageManager" field in package.json.
+      # Do not set `version` here as well, or action-setup errors on the mismatch.
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10.6.2
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
 
       - name: Install dependencies


### PR DESCRIPTION
Follow-up to #295. The first Pages run failed at the pnpm setup step:

> Multiple versions of pnpm specified: `version` in the action config vs `packageManager` in package.json.

Fix: drop the explicit `version` from `pnpm/action-setup` (it reads the pinned version from `package.json`'s `packageManager` field) and bump Node 20 → 22 to clear the runner deprecation warning.

Merging this re-triggers the deploy via push-to-main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)