### PR TITLE
Step 2: cut GitHub Pages over to docs.justifi.tech

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -2,14 +2,13 @@ name: Deploy to GitHub Pages
 
 # Deploys the Docusaurus site to GitHub Pages.
 #
-# Step 1 (current): served at https://justifi-tech.github.io/public-docs/
-#   SITE_BASE_URL must be '/public-docs/' so assets resolve under the
-#   project-page path.
+# Serves at the custom domain https://docs.justifi.tech/ (Step 2 cutover).
+# The domain is pinned by static/CNAME; SITE_BASE_URL is '/' because the site
+# is served at the domain root (no project-page path prefix).
 #
-# Step 2 (custom domain, later): to serve at https://docs.justifi.tech/,
-#   set SITE_URL to https://docs.justifi.tech and SITE_BASE_URL to '/',
-#   add the domain under Settings > Pages, and commit a static/CNAME file
-#   containing "docs.justifi.tech".
+# NOTE: merging this triggers the cutover. The old staging URL
+# https://justifi-tech.github.io/public-docs/ will break once baseUrl is '/'.
+# Do not merge until DNS for docs.justifi.tech is ready to point at Pages.
 
 on:
   # Manual trigger so we control when the trial site publishes.
@@ -35,8 +34,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      SITE_URL: https://justifi-tech.github.io
-      SITE_BASE_URL: /public-docs/
+      SITE_URL: https://docs.justifi.tech
+      SITE_BASE_URL: /
     steps:
       - uses: actions/checkout@v4
 

--- a/static/CNAME
+++ b/static/CNAME
@@ -1,0 +1,1 @@
+docs.justifi.tech


### PR DESCRIPTION
**DRAFT — do not merge until you're ready to move DNS. Merging performs the cutover.**

Follow-up to the initial GitHub Pages setup (#295/#296). Switches the Pages deploy from the staging project-page URL to the production custom domain.

## Changes
- Workflow env: `SITE_URL=https://docs.justifi.tech`, `SITE_BASE_URL=/` (was `justifi-tech.github.io` / `/public-docs/`).
- Adds `static/CNAME` = `docs.justifi.tech` (pins the custom domain on each deploy).

## Verification
Built locally with the new settings (`SITE_URL=https://docs.justifi.tech SITE_BASE_URL=/ pnpm build`):
- `[SUCCESS]` — `onBrokenLinks: "throw"` gate passed.
- `build/CNAME` contains `docs.justifi.tech`.
- Assets reference root paths (`/assets/...`); **zero** `/public-docs/` references remain.

## ⚠️ This is a hard cutover
- The moment this deploys, the staging URL `https://justifi-tech.github.io/public-docs/` **breaks** (baseUrl becomes `/`).
- The moment DNS points `docs.justifi.tech` at Pages, it **stops serving from Vercel**. No overlap.

## Recommended runbook (all on your side)
1. In GitHub → **Settings → Pages → Custom domain**, enter `docs.justifi.tech` and save (it also writes/expects the CNAME this PR adds).
2. At your DNS provider, repoint `docs.justifi.tech` from Vercel to GitHub Pages:
   - `CNAME` → `justifi-tech.github.io` (for a subdomain like `docs`), per GitHub's [custom domain docs](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site).
3. Merge this PR (or run the workflow manually) to publish the root-based build.
4. Wait for DNS propagation, then enable **Enforce HTTPS** in Settings → Pages.
5. Verify `https://docs.justifi.tech/gettingStarted` loads (no `/public-docs/` prefix needed).
6. Decommission the Vercel deploy once confirmed.

Do steps 1–2 first (or close together) so the domain is claimed before/as it flips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)