### PR TITLE
fix: align payment method schemas with vault serializers

### DIFF
--- a/openapi/multi-yaml/components/schemas/BankAccount.yaml
+++ b/openapi/multi-yaml/components/schemas/BankAccount.yaml
@@ -15,8 +15,10 @@ properties:
     example: checking
   bank_name:
     description: bank name
+    type: string
     example: Wells Fargo
-  account_number_last4:
+    nullable: true
+  acct_last_four:
     description: last 4 digits of the account number
     type: string
     example: 1111
@@ -30,3 +32,4 @@ properties:
     format: json
     description: any useful information you'd like to store alongside this bank account
     example: { new: info }
+    nullable: true

--- a/openapi/multi-yaml/components/schemas/BankAccountPaymentMethodWithStatus.yaml
+++ b/openapi/multi-yaml/components/schemas/BankAccountPaymentMethodWithStatus.yaml
@@ -9,6 +9,14 @@ properties:
     type: string
     example: nil
     nullable: true
+  created_at:
+    type: string
+    format: date-time
+    example: '2024-01-01T12:00:00Z'
+  updated_at:
+    type: string
+    format: date-time
+    example: '2024-01-01T12:00:00Z'
   bank_account:
     $ref: ./BankAccount.yaml
   customer_id:

--- a/openapi/multi-yaml/components/schemas/BankAccountResponse.yaml
+++ b/openapi/multi-yaml/components/schemas/BankAccountResponse.yaml
@@ -17,10 +17,12 @@ properties:
         description: unique signature associated with the payment_method
         type: string
         example: "3aGWnUznQ"
+        nullable: true
       customer_id:
         description: customer_id is a deprecated field. Please use our payment method groups instead.
         type: string
         example: "cust_123abc"
+        nullable: true
       account_id:
         description: account id associated with payment method
         type: string
@@ -61,8 +63,10 @@ properties:
             example: checking
           bank_name:
             description: bank name
+            type: string
             example: Wells Fargo
-          account_number_last4:
+            nullable: true
+          acct_last_four:
             description: last 4 digits of the account number
             type: string
             example: 1111
@@ -76,6 +80,7 @@ properties:
             format: json
             description: any useful information you'd like to store alongside this bank account
             example: { new: info }
+            nullable: true
   page_info:
     description: information for cursor style pagination, is null for single records
     type: string

--- a/openapi/multi-yaml/components/schemas/Card.yaml
+++ b/openapi/multi-yaml/components/schemas/Card.yaml
@@ -20,7 +20,9 @@ properties:
     nullable: true
   name:
     description: card or account holder name
+    type: string
     example: Amanda Kessel
+    nullable: true
   token:
     description: |
       same value as unique card id; can be saved and used to process multiple
@@ -37,6 +39,7 @@ properties:
     format: json
     description: any useful information you'd like to store alongside this card
     example: {}
+    nullable: true
   created_at:
     type: string
     format: date-time

--- a/openapi/multi-yaml/components/schemas/CardPaymentMethodWithBinDetails.yaml
+++ b/openapi/multi-yaml/components/schemas/CardPaymentMethodWithBinDetails.yaml
@@ -9,6 +9,14 @@ properties:
     type: string
     example: nil
     nullable: true
+  created_at:
+    type: string
+    format: date-time
+    example: '2024-01-01T12:00:00Z'
+  updated_at:
+    type: string
+    format: date-time
+    example: '2024-01-01T12:00:00Z'
   card:
     $ref: ./CardWithBinDetails.yaml
   customer_id:

--- a/openapi/multi-yaml/components/schemas/CardPresentResponse.yaml
+++ b/openapi/multi-yaml/components/schemas/CardPresentResponse.yaml
@@ -17,10 +17,12 @@ properties:
         description: unique signature associated with the payment_method
         type: string
         example: "3aGWnUznQ"
+        nullable: true
       customer_id:
         description: customer_id is a deprecated field. Please use our payment method groups instead.
         type: string
         example: "cust_123abc"
+        nullable: true
       account_id:
         description: account id associated with payment method
         type: string
@@ -35,6 +37,14 @@ properties:
         type: string
         example: "INVALID_ACCOUNT_NUMBER"
         nullable: true
+      created_at:
+        type: string
+        format: date-time
+        example: '2024-01-01T12:00:00Z'
+      updated_at:
+        type: string
+        format: date-time
+        example: '2024-01-01T12:00:00Z'
       card_present:
         description: the card present payment method
         type: object

--- a/openapi/multi-yaml/components/schemas/CardResponse.yaml
+++ b/openapi/multi-yaml/components/schemas/CardResponse.yaml
@@ -17,10 +17,12 @@ properties:
         description: unique signature associated with the payment_method
         type: string
         example: "3aGWnUznQ"
+        nullable: true
       customer_id:
         description: customer_id is a deprecated field. Please use our payment method groups instead.
         type: string
         example: "cust_123abc"
+        nullable: true
       account_id:
         description: account id associated with payment method
         type: string
@@ -56,6 +58,7 @@ properties:
             description: card holder name
             type: string
             example: Lindsay Whalen
+            nullable: true
           acct_last_four:
             description: last 4 digits of the account number
             type: string
@@ -84,8 +87,9 @@ properties:
           metadata:
             type: object
             format: json
-            description: any useful information you'd like to store alongside this bank account
+            description: any useful information you'd like to store alongside this card
             example: { new: info }
+            nullable: true
           address_line1_check:
             description: >-
               Result of the address line 1 verification check. `pass` — matches the cardholder's address on file;

--- a/openapi/multi-yaml/components/schemas/CardWithBinDetails.yaml
+++ b/openapi/multi-yaml/components/schemas/CardWithBinDetails.yaml
@@ -20,7 +20,9 @@ properties:
     nullable: true
   name:
     description: card or account holder name
+    type: string
     example: Amanda Kessel
+    nullable: true
   token:
     description: |
       same value as unique card id; can be saved and used to process multiple
@@ -37,14 +39,7 @@ properties:
     format: json
     description: any useful information you'd like to store alongside this card
     example: {}
-  created_at:
-    type: string
-    format: date-time
-    example: '2021-01-01T12:00:00Z'
-  updated_at:
-    type: string
-    format: date-time
-    example: '2021-01-01T12:00:00Z'
+    nullable: true
   address_line1_check:
     description: >-
       Result of the address line 1 verification check. `pass` — matches the cardholder's address on file;


### PR DESCRIPTION
## Summary

Audited the payment method OpenAPI schemas against the V1 serializers in the `vault` repo (`payment_method_serializer.rb`, `card_serializer.rb`, `bank_account_serializer.rb`, `card_present_serializer.rb`) and **verified each fix against live API responses** for a card, bank account, and card present payment method.

## Changes

| File | Change |
|---|---|
| `BankAccount.yaml` | `account_number_last4` → `acct_last_four`; `bank_name` +`type`/`nullable`; `metadata` nullable |
| `BankAccountResponse.yaml` | same three; + `signature`/`customer_id` nullable |
| `BankAccountPaymentMethodWithStatus.yaml` | added `created_at`/`updated_at` |
| `CardResponse.yaml` | `card.name`/`card.metadata` nullable (+ fixed copy-pasted "bank account" desc); `signature`/`customer_id` nullable |
| `Card.yaml` / `CardWithBinDetails.yaml` | `name` +`type`/`nullable`; `metadata` nullable |
| `CardWithBinDetails.yaml` | removed erroneous card-level `created_at`/`updated_at` (serializer emits these at the payment-method top level, not inside `card`) |
| `CardPaymentMethodWithBinDetails.yaml` | added `created_at`/`updated_at` |
| `CardPresentResponse.yaml` | added `created_at`/`updated_at`; `signature`/`customer_id` nullable |

### Most impactful fix
`account_number_last4` → `acct_last_four`. The old field name **does not exist anywhere in the API** — the serializer emits `acct_last_four`, matching card payment methods and entity bank accounts. Confirmed against a live response (returned `"acct_last_four": "..."`).

## Scope safety
All edits are scoped to payment methods. The payout (`PayoutBankAccount.yaml`) and entity (`EntityBankAccount.yaml`) bank-account schemas are **separate files and untouched** — `BankAccount.yaml`/`BankAccountResponse.yaml` are only `$ref`'d by payment-method schemas.

## Validation
- `pnpm run build` succeeds. Pre-existing warnings (`allOf` on list envelope, one broken anchor in `configurableFees`) are unrelated to these changes.
- Verified against 3 live payment method lookups (card, bank account, card present).

## Not included
The unused base schemas `CardPaymentMethod.yaml` and `BankAccountPaymentMethod.yaml` are stale and referenced by nothing — left as-is; can remove in a follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)