### PR TITLE
docs: add stable URL for PGP public key

### DIFF
--- a/openapi/docs/payment_method_migration.md
+++ b/openapi/docs/payment_method_migration.md
@@ -16,7 +16,7 @@ Once you understand the basics, you will want to [import a public key](http://ww
 |**Key Size**|4096|
 
 
-You can also download the key directly from a fixed URL: [`https://docs.justifi.tech/security/pgp-public-key.asc`](/security/pgp-public-key.asc)
+**PGP Public Key File**: [https://docs.justifi.tech/security/pgp-public-key.asc](/security/pgp-public-key.asc)
 
 ##### Public Key
 ```bash

--- a/static/security/pgp-public-key.asc
+++ b/static/security/pgp-public-key.asc
@@ -1,25 +1,3 @@
-## Data Import
-JustiFi enables you to transfer your existing customer data and payment methods.  Please contact our [Customer Success Department](mailto:customer_success@justifi.tech) to begin work with your existing processor to securely transfer your information.
-
-### PGP Encryption
-Many processors utilize PGP to encrypt sensative data.  You can find useful information about PGP by looking over the [GPG](http://gnupg.org/) documentation.
-Once you understand the basics, you will want to [import a public key](http://www.gnupg.org/gph/en/manual.html#AEN84).  Please contact our [Customer Success Department](mailto:customer_success@justifi.tech) if you have any questions.
-
-#### JusitiFi's PGP migration key
-
-|  |  |
-|--|--|
-|**Key ID** |`A4546473910D638E`|
-|**User ID**|`JustiFi Import Key (PCI) support-migrations@justifi.tech`|
-|**Fingerprint**|`0E7C 2E45 F62D 98D7 F7B8 776B A454 6473 910D 638E`|
-|**Key Type**|`RSA`|
-|**Key Size**|4096|
-
-
-You can also download the key directly from a fixed URL: [`https://docs.justifi.tech/security/pgp-public-key.asc`](/security/pgp-public-key.asc)
-
-##### Public Key
-```bash
 -----BEGIN PGP PUBLIC KEY BLOCK-----
 
 mQINBGS+8MwBEACibKFR3bZb4huE7piU0fX3zbLpIq+Jnvs79v5ywVMYvu1kgzbb
@@ -72,19 +50,3 @@ yKo41dXUSqDDCGBdzkc4CMMSirF63SJI6qnlvof1apzbwN3JQGSmaL1ROcIviHjs
 8M9w1S9P69JkFyMzGYZExD+cHWYA10DHjM4mSWCBxZ+tC3UirA==
 =SSDk
 -----END PGP PUBLIC KEY BLOCK-----
-```
-
-
-#### Importing and using our key
-
-1. Copy JustiFi's migration key into a new file named `public.key`
-2. Run the GPG command to import the key.
-```sh
-gpg --import public.key
-```
-3. Encrypt your file using the newly imported key.  This will create an encrypted file named `import_file.json.gpg`.
-```sh
-gpg --encrypt --recipient A4546473910D638E import_file.json
-```
-
-


### PR DESCRIPTION
## Summary
- Fortis requires a URL linking to the receiving gateway's (JustiFi's) PGP public encryption key as part of their integration checklist.
- Hosts the current `JustiFi Import Key (PCI)` public key as a static asset at a fixed URL: `https://docs.justifi.tech/security/pgp-public-key.asc`. It's a minimal export (current signature only) verified byte-identical to the key already published in the payment method migration doc, so it's the same trusted key, just also reachable via a direct link.
- Links to that URL from the existing PGP key section in `openapi/docs/payment_method_migration.md`.

[Engineering Artifacts #2942](https://github.com/justifi-tech/engineering-artifacts/issues/2942)

## Steps for Testing/QA
1. `pnpm run build && pnpm run serve`
2. `curl -s http://localhost:3000/security/pgp-public-key.asc` — expect the raw ASCII-armored PGP public key block back.
3. `curl -s http://localhost:3000/security/pgp-public-key.asc | gpg --with-fingerprint --show-keys` — expect fingerprint `0E7C2E45F62D98D7F7B8776BA4546473910D638E` / key ID `A4546473910D638E`.
4. Visit the Data Import page and confirm the new "download the key directly from a fixed URL" link renders under the key metadata table.