### PR TITLE
chore: update Payables API spec to 6ac488c

### DIFF
--- a/openapi/payables/public.bundled.json
+++ b/openapi/payables/public.bundled.json
@@ -86,9 +86,7 @@
         "tags": [
           "API Credentials"
         ],
-        "security": [
-
-        ],
+        "security": [],
         "requestBody": {
           "required": true,
           "content": {
@@ -266,6 +264,26 @@
               "example": "biz_123xyz"
             },
             "description": "filter to the payer accounts belonging to a single business. Use this to resolve a business's\npayer account(s) from the `biz_…` id you already hold — a business holds one payer account, so\nit returns a single record.\n\n"
+          },
+          {
+            "in": "query",
+            "name": "name",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "northside"
+            },
+            "description": "filter payer accounts to those whose `name` contains this value, case-insensitively. Partial\nmatches count, so `northside` matches \"Northside Physical Therapy\" — this backs the type-ahead\nin the account switcher rather than an exact-name lookup.\n"
+          },
+          {
+            "in": "query",
+            "name": "payer_id",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "payer_123xyz"
+            },
+            "description": "filter to a single payer account by its `payer_…` id. Matches exactly; an id that is not a\n`payer_…` id is rejected with `400`.\n"
           }
         ],
         "responses": {
@@ -9076,9 +9094,7 @@
         "tags": [
           "Webhooks"
         ],
-        "security": [
-
-        ],
+        "security": [],
         "requestBody": {
           "content": {
             "application/json": {
@@ -9242,9 +9258,7 @@
         "tags": [
           "Webhooks"
         ],
-        "security": [
-
-        ],
+        "security": [],
         "requestBody": {
           "content": {
             "application/json": {
@@ -9475,9 +9489,7 @@
         "tags": [
           "Webhooks"
         ],
-        "security": [
-
-        ],
+        "security": [],
         "requestBody": {
           "content": {
             "application/json": {
@@ -9798,9 +9810,7 @@
         "tags": [
           "Webhooks"
         ],
-        "security": [
-
-        ],
+        "security": [],
         "requestBody": {
           "content": {
             "application/json": {

--- a/openapi/payables/source.json
+++ b/openapi/payables/source.json
@@ -1,7 +1,7 @@
 {
   "source_repo": "justifi-tech/payables",
   "source_path": "openapi/index.yaml",
-  "source_sha": "16c6800894a59bca077205835f38b1f36a4ec68e",
-  "source_committed_at": "2026-08-19T21:00:28Z",
-  "published_at": "2026-08-20T14:00:00Z"
+  "source_sha": "6ac488c384fb3458668ce5c255d7c417799435a9",
+  "source_committed_at": "2026-08-20T13:24:18-05:00",
+  "published_at": "2026-08-20T18:28:22Z"
 }


### PR DESCRIPTION
Derived from `justifi-tech/payables@6ac488c384fb3458668ce5c255d7c417799435a9`, committed 2026-08-20T13:24:18-05:00.

Gate: updating to 6ac488c

Machine-written by `update-payables-spec.yml`. Everything under `openapi/payables/`
is generated and hand edits to it are lost on the next publish — review what the
contract now says, not the file.
