### PR TITLE
docs: allow archiving unprovisioned live businesses

### DIFF
--- a/openapi/multi-yaml/components/schemas/BusinessResponse.yaml
+++ b/openapi/multi-yaml/components/schemas/BusinessResponse.yaml
@@ -11,7 +11,7 @@ properties:
   archived:
     type: boolean
     example: false
-    description: indicates whether this business has been archived; only test mode businesses can be archived
+    description: indicates whether this business has been archived. Test mode businesses can always be archived; a live mode business can only be archived while it has not been provisioned. Archived businesses are excluded from the list businesses endpoint
   legal_name:
     type: string
     example: "Business Name"

--- a/openapi/multi-yaml/paths/entities_business.yaml
+++ b/openapi/multi-yaml/paths/entities_business.yaml
@@ -16,7 +16,7 @@ post:
             legal_name:
               type: string
               example: "Business Name"
-              description: legal business entity name
+              description: legal business entity name; must be unique among the active businesses on your platform. Archived businesses do not reserve their name, so an archived business's legal_name can be reused
             website_url:
               type: string
               example: "https://justifi.ai"
@@ -144,7 +144,7 @@ post:
 get:
   summary: List Businesses
   description: |
-    List businesses for your platform. This endpoint supports [pagination](https://docs.justifi.tech/api-spec#section/Pagination).
+    List businesses for your platform. Archived businesses are not returned. This endpoint supports [pagination](https://docs.justifi.tech/api-spec#section/Pagination).
   operationId: ListBusinesses
   tags:
     - Business

--- a/openapi/multi-yaml/paths/entities_business@{id}.yaml
+++ b/openapi/multi-yaml/paths/entities_business@{id}.yaml
@@ -16,7 +16,7 @@ patch:
             archived:
               type: boolean
               example: true
-              description: set to true to archive this business; only test mode businesses can be archived, attempting to archive a live mode business will return an error
+              description: set to true to archive this business. Test mode businesses can always be archived. A live mode business can only be archived while it has not been provisioned; once a product has been provisioned for it, or a sub account is associated with it, archiving returns an error. Archiving frees the business's legal_name for reuse, so setting this back to false returns an error if another active business on your platform has taken that name in the meantime
             legal_name:
               type: string
               example: "Business Name"

--- a/openapi/multi-yaml/paths/entities_provisioning.yaml
+++ b/openapi/multi-yaml/paths/entities_provisioning.yaml
@@ -2,6 +2,8 @@ post:
   summary: Product Provisioning
   description: |
     Product Provisioning
+
+    An archived business cannot be provisioned. Un-archive it first by sending `archived: false` to the update business endpoint.
   operationId: ProductProvisioning
   tags:
     - Provisioning


### PR DESCRIPTION
Documents the API behavior change in justifi-tech/entity_management#575.

Previously the docs said only test mode businesses could be archived. Live businesses can now be archived while they have not been provisioned, and archiving frees the business's `legal_name` for reuse.

## Changes

| File | Change |
|---|---|
| `paths/entities_business@{id}.yaml` | `archived` request field: describes the live-mode rule (blocked once a product is provisioned or a sub account is associated) and that un-archiving fails if another active business has taken the name in the meantime |
| `components/schemas/BusinessResponse.yaml` | `archived` response field: same rule, plus the pre-existing detail that archived businesses are excluded from the list endpoint |
| `paths/entities_business.yaml` | `legal_name` on create: uniqueness is scoped to *active* businesses, so an archived business's name can be reused. List endpoint: states archived businesses are not returned |
| `paths/entities_provisioning.yaml` | Notes that an archived business cannot be provisioned, and how to un-archive |

## Verification

All four edited files parse as YAML and the descriptions resolve to the intended text. I could not run `pnpm run prebuild` / `build` locally — `node_modules` in this checkout is missing `js-yaml`, so `scripts/merge-payables-spec.mjs` cannot run without a fresh `pnpm install`. These are description-only string edits with no structural or `$ref` changes, so the merge step should be unaffected, but CI's build is the real gate.

## Not covered

Two pre-existing gaps I left alone as out of scope:
- The `provisioned` array returned by the business endpoints is not documented in `BusinessResponse.yaml`, even though it is what determines archivability.
- `associated_accounts` in `BusinessResponse.yaml` has a `descriptin:` typo, so that description is not rendering at all.

Refs justifi-tech/engineering-artifacts#3390

🤖 Generated with [Claude Code](https://claude.com/claude-code)
