### PR TITLE
docs: document the new top-level id on payment method responses

### DIFF
--- a/openapi/multi-yaml/components/schemas/BankAccountPaymentMethodWithStatus.yaml
+++ b/openapi/multi-yaml/components/schemas/BankAccountPaymentMethodWithStatus.yaml
@@ -1,5 +1,9 @@
 type: object
 properties:
+  id:
+    description: unique id of the payment method
+    type: string
+    example: pm_123xyz
   status:
     description: signals whether the payment method is valid or invalid
     type: string

--- a/openapi/multi-yaml/components/schemas/BankAccountResponse.yaml
+++ b/openapi/multi-yaml/components/schemas/BankAccountResponse.yaml
@@ -13,6 +13,10 @@ properties:
     description: the attributes for the object
     type: object
     properties:
+      id:
+        description: unique id of the payment method
+        type: string
+        example: pm_123xyz
       signature:
         description: unique signature associated with the payment_method
         type: string

--- a/openapi/multi-yaml/components/schemas/CardPaymentMethodWithBinDetails.yaml
+++ b/openapi/multi-yaml/components/schemas/CardPaymentMethodWithBinDetails.yaml
@@ -1,5 +1,9 @@
 type: object
 properties:
+  id:
+    description: unique id of the payment method
+    type: string
+    example: pm_123xyz
   status:
     description: signals whether the payment method is valid or invalid
     type: string

--- a/openapi/multi-yaml/components/schemas/CardPresentPaymentMethod.yaml
+++ b/openapi/multi-yaml/components/schemas/CardPresentPaymentMethod.yaml
@@ -1,5 +1,9 @@
 type: object
 properties:
+  id:
+    description: unique id of the payment method
+    type: string
+    example: pm_123xyz
   status:
     description: signals whether the payment method is valid or invalid
     type: string

--- a/openapi/multi-yaml/components/schemas/CardPresentResponse.yaml
+++ b/openapi/multi-yaml/components/schemas/CardPresentResponse.yaml
@@ -13,6 +13,10 @@ properties:
     description: the attributes for the object
     type: object
     properties:
+      id:
+        description: unique id of the payment method
+        type: string
+        example: pm_123xyz
       signature:
         description: unique signature associated with the payment_method
         type: string

--- a/openapi/multi-yaml/components/schemas/CardResponse.yaml
+++ b/openapi/multi-yaml/components/schemas/CardResponse.yaml
@@ -13,6 +13,10 @@ properties:
     description: the attributes for the object
     type: object
     properties:
+      id:
+        description: unique id of the payment method
+        type: string
+        example: pm_123xyz
       signature:
         description: unique signature associated with the payment_method
         type: string

--- a/openapi/multi-yaml/events/payment_methods.yaml
+++ b/openapi/multi-yaml/events/payment_methods.yaml
@@ -13,9 +13,16 @@ post:
             - $ref: ../components/schemas/Event.yaml
             - properties:
                 data:
-                  oneOf:
-                    - $ref: ../components/schemas/CardPaymentMethod.yaml
-                    - $ref: ../components/schemas/BankAccountPaymentMethod.yaml
+                  allOf:
+                    - oneOf:
+                        - $ref: ../components/schemas/CardPaymentMethod.yaml
+                        - $ref: ../components/schemas/BankAccountPaymentMethod.yaml
+                    - type: object
+                      properties:
+                        id:
+                          description: unique id of the payment method
+                          type: string
+                          example: pm_123xyz
         example:
         examples:
           "Card_payment_method_created_event":
@@ -28,6 +35,7 @@ post:
               request_id: req_100abc
               version: v1
               data:
+                id: pm_123xyz
                 signature: 9fxy123
                 customer_id: cust_987zyx
                 status: valid
@@ -54,6 +62,7 @@ post:
               request_id: req_100abc
               version: v1
               data:
+                id: pm_123xyz
                 signature: 9fxy123
                 customer_id: cust_987zyx
                 status: valid
@@ -76,6 +85,7 @@ post:
               request_id: req_100abc
               version: v1
               data:
+                id: pm_123xyz
                 signature: 9fxy123
                 customer_id: cust_987zyx
                 status: valid


### PR DESCRIPTION
Documents the `id` field that [justifi-tech/vault#1822](https://github.com/justifi-tech/vault/pull/1822) adds to payment method responses. **Merge after that PR ships.**

## What changed in the API

Payment method responses now carry `id` (the `pm_`-prefixed payment method id) as a top-level attribute. Previously the only way to get it was out of the nested `card` / `bank_account` / `card_present` object — and on `List Payment Methods` there was no way to get it at all, since the envelope `id` is `null` for collections.

Purely additive; the nested `id` and `token` fields are unchanged.

## Schemas updated

**Show / create / update / clone** — added inside `data`:
- `CardResponse.yaml`
- `BankAccountResponse.yaml`
- `CardPresentResponse.yaml`

**List Payment Methods, and payment intents:**
- `CardPaymentMethodWithBinDetails.yaml`
- `BankAccountPaymentMethodWithStatus.yaml`
- `CardPresentPaymentMethod.yaml`

The first two are also `$ref`'d by `CardPaymentIntent.yaml` / `BankAccountPaymentIntent.yaml`. That's intentional — payment intents serialize their payment method through the same code path, so they gain the field too.

**Webhooks** — `events/payment_methods.yaml`, covering `payment_method.created`, `.updated` and `.bin_mapped`, with all three examples updated to show the new field.

## Note for reviewers: what is deliberately NOT changed

`CardPaymentMethod.yaml` and `BankAccountPaymentMethod.yaml` are untouched.

Those two are shared between the webhook payload **and** the `payment_method` embedded in payment responses — and payment responses do **not** gain an `id`. That serializer intentionally mirrors the capital service's payment API field-for-field, so adding `id` on one side only would make the two diverge.

So the webhook's `id` is added inline in `events/payment_methods.yaml` via `allOf` rather than on the shared schemas. Slightly more verbose, but it keeps the payment response docs accurate.

Payment responses continue to expose the payment method id only at `payment_method.card.id` / `payment_method.bank_account.id`.

## Testing

`pnpm run build` passes. The one broken-anchor warning it emits is pre-existing and in `/configurableFees/`, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)