### PR TITLE
fix: document mode and provisioned on BusinessResponse

### DIFF
--- a/openapi/multi-yaml/components/schemas/BusinessResponse.yaml
+++ b/openapi/multi-yaml/components/schemas/BusinessResponse.yaml
@@ -8,6 +8,11 @@ properties:
     type: string
     format: uuid
     example: acc_xyz
+  mode:
+    type: string
+    enum: [test, live]
+    example: test
+    description: whether this business is a test or live business, set from the credentials used to create it and fixed for the life of the business
   archived:
     type: boolean
     example: false
@@ -96,9 +101,22 @@ properties:
     format: json
     description: any useful information you'd like to store alongside this business
   associated_accounts:
-    type: array of objects
-    descriptin: the id of the sub account associated with the business, is populated once the business has been provisioned
-    example: [{ id: acc_123xyx }]
+    type: array
+    description: the sub account associated with this business, populated once the business has been provisioned
+    items:
+      type: object
+      properties:
+        id:
+          type: string
+          example: acc_123xyz
+    example: [{ id: acc_123xyz }]
+  provisioned:
+    type: array
+    description: products successfully provisioned for this business, empty until a provisioning request succeeds. This list reflects completed provisioning only. A business whose provisioning is still in flight, or that already has a sub account associated, reports an empty list but can no longer be archived
+    items:
+      type: string
+      enum: [payments, underwriting, boarding, bank_account_verification]
+    example: ["payments", "underwriting"]
   legal_address:
     $ref: AddressResponse.yaml
   representative:


### PR DESCRIPTION
Follow-up to #314, closing the two gaps that PR listed as out of scope, plus `mode`.

All changes are in `openapi/multi-yaml/components/schemas/BusinessResponse.yaml`.

## Changes

| Field | Change |
|---|---|
| `provisioned` | **New.** The array of successfully provisioned products was returned by the API but undocumented. Typed as an array of strings with the enum `payments`, `underwriting`, `boarding`, `bank_account_verification` |
| `associated_accounts` | Fixed the `descriptin:` typo, so the description renders for the first time. Also replaced `type: array of objects` — not a valid OpenAPI type — with a real `type: array` plus an `items` object schema |
| `mode` | **New.** Returned by the serializer but undocumented. Enum `test` / `live` |

## Sourcing

Values were read from `justifi-tech/entity_management`, not inferred:

- `provisioned` comes from `V1::Entities::BusinessSerializer#provisioned`, which maps succeeded `provisioning_records` through `ProvisioningRecord::PROVIDER_TO_GENERIC_NAME` — hence `underwriting` covering both the `jaris` and `infinicept` providers, and `bank_account_verification` covering `plaid`.
- `mode` is assigned only on the create path in `Entities::CreateOrUpdateBusiness` (`new_business.mode = Business.modes[:live] if platform_account.live_mode?`), derived from the credentials' platform account. It is never a client-supplied parameter and never reassigned on update, which is why the description calls it fixed for the life of the business.

### One correction to #314's framing

That PR described `provisioned` as "what determines archivability". It isn't, quite. The serializer filters on `status_succeeded?`, but `Business#provisioned?` — the validation that actually blocks archiving — returns true for `submitted` **or** `succeeded`, and short-circuits true whenever `account_id` is present. A business mid-provisioning therefore reports `provisioned: []` while already failing to archive. The description states this explicitly rather than implying the array is a reliable archivability check.

## Verification

`pnpm run build` succeeds, and all three fields resolve into the rendered spec at `build/redocusaurus/plugin-redoc-0.yaml`. The build needed a `pnpm install` first — the missing `js-yaml` that blocked local verification on #314 is now restored, so this change was checked against a real build rather than a YAML parse alone.

The remaining build warning — a broken anchor on `/configurableFees/overview` — is pre-existing and unrelated.

## Not covered

`product_categories` and `settings` are returned by the serializer and still undocumented. Deliberately left for a separate change.

Refs justifi-tech/engineering-artifacts#3390

🤖 Generated with [Claude Code](https://claude.com/claude-code)
