### PR TITLE
chore: update Payables API spec to 2136940

### DIFF
--- a/openapi/payables/public.bundled.json
+++ b/openapi/payables/public.bundled.json
@@ -1123,7 +1123,7 @@
             },
             "required": false,
             "example": "2026-01-01T00:00:00Z",
-            "description": "filter records created after the date and time (UTC) specified. Dates without a time default to 00:00:00\n"
+            "description": "filter records created strictly after the date and time (UTC) specified. Dates without a time default to\n00:00:00. ISO 8601 only — a value that is not one is a `400`, never a filter that silently does nothing\n"
           },
           {
             "in": "query",
@@ -1134,7 +1134,7 @@
             },
             "required": false,
             "example": "2026-01-01T00:00:00Z",
-            "description": "filter records created before the date and time (UTC) specified. Dates without a time default to 00:00:00\n"
+            "description": "filter records created strictly before the date and time (UTC) specified. Dates without a time default to\n00:00:00. ISO 8601 only — a value that is not one is a `400`, never a filter that silently does nothing\n"
           },
           {
             "in": "query",
@@ -5389,7 +5389,7 @@
             },
             "required": false,
             "example": "2026-01-01T00:00:00Z",
-            "description": "filter records created after the date and time (UTC) specified. Dates without a time default to 00:00:00\n"
+            "description": "filter records created strictly after the date and time (UTC) specified. Dates without a time default to\n00:00:00. ISO 8601 only — a value that is not one is a `400`, never a filter that silently does nothing\n"
           },
           {
             "in": "query",
@@ -5400,7 +5400,7 @@
             },
             "required": false,
             "example": "2026-01-01T00:00:00Z",
-            "description": "filter records created before the date and time (UTC) specified. Dates without a time default to 00:00:00\n"
+            "description": "filter records created strictly before the date and time (UTC) specified. Dates without a time default to\n00:00:00. ISO 8601 only — a value that is not one is a `400`, never a filter that silently does nothing\n"
           },
           {
             "in": "query",
@@ -5416,7 +5416,8 @@
                 "succeeded",
                 "failed",
                 "refunding_payer",
-                "refunded"
+                "refunded",
+                "failed_late_return"
               ]
             },
             "description": "filter payments by lifecycle status"
@@ -5428,7 +5429,8 @@
             "schema": {
               "type": "string"
             },
-            "description": "filter payments to a single payee"
+            "example": "pe_abc123",
+            "description": "filter payments to a single payee, by its `pe_` id"
           }
         ],
         "responses": {
@@ -7713,7 +7715,7 @@
             },
             "required": false,
             "example": "2026-01-01T00:00:00Z",
-            "description": "filter records created after the date and time (UTC) specified. Dates without a time default to 00:00:00\n"
+            "description": "filter records created strictly after the date and time (UTC) specified. Dates without a time default to\n00:00:00. ISO 8601 only — a value that is not one is a `400`, never a filter that silently does nothing\n"
           },
           {
             "in": "query",
@@ -7724,7 +7726,7 @@
             },
             "required": false,
             "example": "2026-01-01T00:00:00Z",
-            "description": "filter records created before the date and time (UTC) specified. Dates without a time default to 00:00:00\n"
+            "description": "filter records created strictly before the date and time (UTC) specified. Dates without a time default to\n00:00:00. ISO 8601 only — a value that is not one is a `400`, never a filter that silently does nothing\n"
           },
           {
             "in": "query",
@@ -8176,7 +8178,7 @@
             },
             "required": false,
             "example": "2026-01-01T00:00:00Z",
-            "description": "filter records created after the date and time (UTC) specified. Dates without a time default to 00:00:00\n"
+            "description": "filter records created strictly after the date and time (UTC) specified. Dates without a time default to\n00:00:00. ISO 8601 only — a value that is not one is a `400`, never a filter that silently does nothing\n"
           },
           {
             "in": "query",
@@ -8187,7 +8189,7 @@
             },
             "required": false,
             "example": "2026-01-01T00:00:00Z",
-            "description": "filter records created before the date and time (UTC) specified. Dates without a time default to 00:00:00\n"
+            "description": "filter records created strictly before the date and time (UTC) specified. Dates without a time default to\n00:00:00. ISO 8601 only — a value that is not one is a `400`, never a filter that silently does nothing\n"
           },
           {
             "in": "query",

--- a/openapi/payables/source.json
+++ b/openapi/payables/source.json
@@ -1,7 +1,7 @@
 {
   "source_repo": "justifi-tech/payables",
   "source_path": "openapi/index.yaml",
-  "source_sha": "2e158d1080829b47ef39f3e7adb0373fbe116443",
-  "source_committed_at": "2026-08-24T12:52:12-05:00",
-  "published_at": "2026-08-24T17:52:52Z"
+  "source_sha": "2136940c0748793b38d1d27fac0c4712eb03c321",
+  "source_committed_at": "2026-08-26T13:24:32-05:00",
+  "published_at": "2026-08-26T18:25:16Z"
 }


### PR DESCRIPTION
Derived from `justifi-tech/payables@2136940c0748793b38d1d27fac0c4712eb03c321`, committed 2026-08-26T13:24:32-05:00.

Gate: updating to 2136940

Machine-written by `update-payables-spec.yml`. Everything under `openapi/payables/`
is generated and hand edits to it are lost on the next publish — review what the
contract now says, not the file.
